### PR TITLE
Changed export method

### DIFF
--- a/wp-migrate-db.php
+++ b/wp-migrate-db.php
@@ -37,7 +37,7 @@ if ( !defined( 'DS' ) ) {
 }
 
 if ( ! defined( 'ROWS_PER_SEGMENT' ) ) {
-    define( 'ROWS_PER_SEGMENT', 100 );
+    define( 'ROWS_PER_SEGMENT', 500 );
 }
 
 class WP_Migrate_DB {
@@ -537,6 +537,8 @@ class WP_Migrate_DB {
                 $row_inc = ROWS_PER_SEGMENT;
             }
 
+            $current_row = 1;
+            
             do {
                 $where = '';
                 // We need ORDER BY here because with LIMIT, sometimes it will return
@@ -560,13 +562,31 @@ class WP_Migrate_DB {
                 $sql = "SELECT " . $this->backquote( $table ) . ".* FROM " . $this->backquote( $table ) . " $where LIMIT {$row_start}, {$row_inc}";
 
                 $table_data = $wpdb->get_results( $sql, ARRAY_A );
-
-                $entries = 'INSERT INTO ' . $this->backquote( $table ) . ' VALUES (';
+                
                 //    \x08\\x09, not required
                 $search = array( "\x00", "\x0a", "\x0d", "\x1a" );
                 $replace = array( '\0', '\n', '\r', '\Z' );
                 if ( $table_data ) {
                     foreach ( $table_data as $row ) {
+                        
+                        if ( $current_row == 1 ) {
+                            $start_of_row = "\nINSERT INTO " . $this->backquote( $table ) . " VALUES \n(";
+                            $end_of_row = ', ';
+
+                            if ( count($table_data) == 1 ) {
+                                $end_of_row = '; ';
+                            }
+
+                        } else {
+                            $start_of_row = '(';
+                            $end_of_row = ', ';
+
+                            if ( $current_row == 499 || $current_row == count($table_data) ) {
+                                $end_of_row = '; ';
+                                $current_row = 0;
+                            }
+                        }
+                        
                         $values = array();
                         foreach ( $row as $key => $value ) {
                             if ( isset( $ints[strtolower( $key )] ) && $ints[strtolower( $key )] ) {
@@ -588,10 +608,12 @@ class WP_Migrate_DB {
                                 }
                             }
                         }
-                        $this->stow( " \n" . $entries . implode( ', ', $values ) . ') ;' );
+                        $this->stow( " \n" . $start_of_row . implode( ', ', $values ) . ') ' . $end_of_row );
+                        $current_row++;
                     }
                     $row_start += $row_inc;
                 }
+                
             } while ( ( count( $table_data ) > 0 ) and ( $segment=='none' ) );
         }
 


### PR DESCRIPTION
The plugin export each row as a query, it means that if the exported
database have 10k rows the import tool will execute 10k database queries.
This is not good because make the importing process slow and expensive.

The changes I made it's able to separate each query in 500 rows, it means that
if the database have 10k rows the importing tool will execute only 20 queries.

Beyond less queries the dump now is significantly little compared with
the original dump of this plugin.
