### PR TITLE
fixed bug where migrate db tried to create a new instance of an object w...

### DIFF
--- a/wp-migrate-db.php
+++ b/wp-migrate-db.php
@@ -636,14 +636,9 @@ class WP_Migrate_DB {
             }
             // Submitted by Tina Matter
             elseif ( is_object( $data ) ) {
-                $dataClass = get_class( $data );
-                $_tmp = new $dataClass( );
                 foreach ( $data as $key => $value ) {
-                    $_tmp->$key = $this->recursive_unserialize_replace( $value, false, $parent_serialized );
+                    $data->$key = $this->recursive_unserialize_replace( $value, false, $parent_serialized );
                 }
-
-                $data = $_tmp;
-                unset( $_tmp );
             }
             elseif ( is_string( $data ) ) {
                 $data = $this->apply_replaces( $data, $parent_serialized );


### PR DESCRIPTION
...hich MIGHT have a PRIVATE CONSTRUCTOR.
I'm submitting this pull request because when we used wp-migrate-db with Event Espresso 4 (eventespresso.com), it gave us a fatal error because we're serializing objects to the database (specifically, as transients) which have a PRIVATE CONSTRUCTOR, because we're using them as singletons. (Eg, we have a class called EE_Cart, whose constructor is private, and on which you instead use a static function called instance() to get an instance of the object (and that function can call EE_Cart's constructor if it chooses)). 
Was there some special reason why you needed to create a separate object and modify it, instead of just modifying the object you unserialized?
Anyways, with this change, I was succesfully able to run migrate-db with Event Espresso 4's data. Please let us know your thoughts on this.
