### PR TITLE
Fix assets url for mu-plugins use

### DIFF
--- a/class/wpmdb.php
+++ b/class/wpmdb.php
@@ -3447,7 +3447,7 @@ class WPMDB extends WPMDB_Base {
 		// add our custom CSS classes to <body>
 		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
-		$plugins_url = trailingslashit( plugins_url( $this->plugin_folder_name ) );
+		$plugins_url = trailingslashit( plugins_url( '/', $this->plugin_file_path ) );
 		$version     = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? time() : $this->plugin_version;
 		$ver_string  = '-' . str_replace( '.', '', $this->plugin_version );
 		$min         = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';


### PR DESCRIPTION
Issue: When used as a mu-plugin (for example with https://github.com/wordplate/autoloader/) this plugin tries to load it's style and javascript files from /plugins instead of /mu-plugins